### PR TITLE
Add views count for episodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -182,7 +182,7 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
       value: node.frontmatter.video || "",
     })
 
-    const views = await getVideoViewsCount("738019970309937")
+    const views = await getVideoViewsCount(node.frontmatter.video)
 
     createNodeField({
       name: "views",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5306,6 +5306,13 @@
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        }
       }
     },
     "cross-spawn": {
@@ -13876,9 +13883,9 @@
       "integrity": "sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g="
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-forge": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "isomorphic-fetch": "^2.2.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
+    "node-fetch": "^2.6.0",
     "node-sass": "^4.13.0",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/src/components/Blabla/Episode/index.js
+++ b/src/components/Blabla/Episode/index.js
@@ -14,12 +14,14 @@ const Episode = ({
   audio,
   description,
   repoLink,
+  views,
 }) => (
   <div className="episode">
     <Player video={video} audio={audio} />
     <div className="info">
       <div className="title">
         <p>{date}</p>
+        <p>{views} views</p>
         <h1> {title} </h1>
         <Actions title={title} shareUrl={`https://geeksblabla.com/${slug}`} />
       </div>

--- a/src/components/Blabla/EpisodeItem/index.js
+++ b/src/components/Blabla/EpisodeItem/index.js
@@ -4,7 +4,7 @@ import PlayIcon from "assets/play.svg"
 
 import "./index.scss"
 
-export default ({ title, date, slug, duration, active }) => (
+export default ({ title, date, slug, duration, active, views }) => (
   <Link
     to={`/${slug}`}
     activeClassName="episode-item active"
@@ -17,7 +17,7 @@ export default ({ title, date, slug, duration, active }) => (
     <div>
       <h2>{title}</h2>
       <p>
-        {duration} | {date}
+        {duration} | {date} | {views} views
       </p>
     </div>
   </Link>

--- a/src/components/Blabla/EpisodesMenu/index.js
+++ b/src/components/Blabla/EpisodesMenu/index.js
@@ -22,6 +22,7 @@ export default ({ selectedEpisode }) => (
                 slug
                 date(formatString: "MMMM DD, YYYY")
                 duration
+                views
               }
             }
           }

--- a/src/pages/blablas.js
+++ b/src/pages/blablas.js
@@ -39,6 +39,7 @@ export const pageQuery = graphql`
             video
             repoLink
             audio
+            views
           }
           body
         }

--- a/src/templates/blabla.js
+++ b/src/templates/blabla.js
@@ -38,6 +38,7 @@ export const pageQuery = graphql`
         repoLink
         audio
         tags
+        views
       }
       body
     }


### PR DESCRIPTION
As discussed in #137, this implements adding a views count for episodes by querying the FB Graph API. 

Unfortunately, Facebook does not support getting the number of views for videos created on Facebook groups, only for Facebook pages (more on this [here](https://github.com/DevC-Casa/geeksblabla.com/issues/137#issuecomment-663892076)). 

@yjose I am creating this pull request just so you can see if I need to change anything while waiting for Facebook to review the app. 

Thanks and please let me know what you think :pray: